### PR TITLE
Monitoring

### DIFF
--- a/etc/apache2/conf.d/vhost.conf
+++ b/etc/apache2/conf.d/vhost.conf
@@ -20,6 +20,21 @@ LoadModule rewrite_module modules/mod_rewrite.so
 
     DocumentRoot /var/www/html
 
+    Alias /real-time-status "/usr/local/php/php/fpm/status.html"
+    <Directory /usr/local/php/php/fpm >
+        Require all granted
+    </Directory>
+
+    <Location /status >
+        SetHandler "proxy:unix:/var/run/php-fpm/php-fpm.sock|fcgi://localhost/"
+        Require all granted
+    </Location>
+
+    <Location /server-status >
+        SetHandler server-status
+        Require all granted
+    </Location>
+
     ErrorLog /dev/stderr
     CustomLog /dev/stdout common
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -80,6 +80,21 @@ export BATS_PHP_DOCKER_IMAGE_NAME="${PHP_DOCKER_IMAGE_NAME:-docker.io/elasticms/
   assert_output -l -r "Check MySQL Connection Done."
 }
 
+@test "[$TEST_FILE] Check for Monitoring /real-time-status page response code 200" {
+  retry 12 5 curl_container php :9000/real-time-status -H "Host: default.localhost" -s -w %{http_code} -o /dev/null
+  assert_output -l 0 $'200'
+}
+
+@test "[$TEST_FILE] Check for Monitoring /status page response code 200" {
+  retry 12 5 curl_container php :9000/status -H "Host: default.localhost" -s -w %{http_code} -o /dev/null
+  assert_output -l 0 $'200'
+}
+
+@test "[$TEST_FILE] Check for Monitoring /server-status page response code 200" {
+  retry 12 5 curl_container php :9000/server-status -H "Host: default.localhost" -s -w %{http_code} -o /dev/null
+  assert_output -l 0 $'200'
+}
+
 @test "[$TEST_FILE] Stop all and delete test containers" {
   command docker-compose -f docker-compose.yml stop
   command docker-compose -f docker-compose.yml rm -v -f  


### PR DESCRIPTION
Expose some metrics through the default Apache vhost.
Theses metrics can be, for example, retrieved by Prometheus exporter for publishing to Grafana.